### PR TITLE
Fix: Correct verb tense in theory section

### DIFF
--- a/index.html
+++ b/index.html
@@ -911,7 +911,7 @@
                     <div class="sentence-highlight">
                         <span class="subject">O Miguel</span> <span class="predicate">ofereceu <span class="predicate-part">flores</span> <span class="predicate-part">à namorada</span> <span class="predicate-part">ontem</span> <span class="predicate-part">no parque</span></span>.
                     </div>
-                    <p>Verbo: ofereceu | CD: flores | CI: à namorada | Adjuntos: ontem (tempo), no parque (lugar)</p>
+                    <p>Verbo: oferecer | CD: flores | CI: à namorada | Adjuntos: ontem (tempo), no parque (lugar)</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Changed 'Verbo: ofereceu' to 'Verbo: oferecer' in the predicate examples under the Theory tab to reflect the infinitive form of the verb.