### PR TITLE
Refatorei o exercício em Prática Guiada (Médio) para complex-analysis.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1139,11 +1139,11 @@
                     hint: 'O predicado inclui tudo menos o sujeito.'
                 },
                 {
-                    type: 'identify-parts',
+                    type: 'complex-analysis', // Alterado
                     question: 'Identifica os componentes do predicado:',
                     sentence: 'A professora explicou a matéria aos alunos.',
-                    predicate: 'explicou a matéria aos alunos',
-                    parts: {
+                    // 'predicate' removido pois não é usado por complex-analysis em loadPracticeExercise
+                    components: { // Renomeado de 'parts'
                         verbo: 'explicou',
                         cd: 'a matéria',
                         ci: 'aos alunos'


### PR DESCRIPTION
Alterei o exercício "A professora explicou a matéria aos alunos." na secção "Prática Guiada" de dificuldade "Médio" para usar o tipo 'complex-analysis'.

Anteriormente, este exercício era do tipo 'identify-parts'. Esta alteração visa uniformizar os tipos de exercício e reutilizar a lógica existente para 'complex-analysis'.

Modificações:
1.  A estrutura do exercício no objeto `exercisesByDifficulty.medio` foi alterada:
    - `type` mudado de 'identify-parts' para 'complex-analysis'.
    - A propriedade `parts` foi renomeada para `components`.
    - A propriedade `predicate` foi removida por não ser utilizada pela lógica de 'complex-analysis'.
2.  A lógica específica para o tipo 'identify-parts' (que foi temporariamente adicionada e depois considerada desnecessária ou incorretamente implementada no lado do cliente) foi removida das funções `loadPracticeExercise` e `checkPracticeAnswer` para evitar código morto.

Os testes manuais confirmaram que o exercício é agora corretamente carregado e avaliado usando a lógica de 'complex-analysis'.