### PR TITLE
Fixed a bug in the 'View Analysis' button of the Surprise Challenge

### DIFF
--- a/index.html
+++ b/index.html
@@ -1077,6 +1077,18 @@
     </button>
 
     <script>
+        function escapeHtmlAttr(unsafe) {
+            if (typeof unsafe !== 'string') {
+                return unsafe; // Retorna o valor original se não for uma string
+            }
+            return unsafe
+                 .replace(/&/g, "&amp;")
+                 .replace(/</g, "&lt;")
+                 .replace(/>/g, "&gt;")
+                 .replace(/"/g, "&quot;")
+                 .replace(/'/g, "&#039;"); // Essencial para atributos onclick delimitados por aspas simples
+        }
+
         // Dados dos exercícios
         const exercisesByDifficulty = {
             facil: [
@@ -1547,6 +1559,10 @@
         // Modo Surpresa
         function loadSurprise() {
             const quote = authorQuotes[Math.floor(Math.random() * authorQuotes.length)];
+
+            const escapedPredicate = escapeHtmlAttr(quote.predicate);
+            const escapedType = escapeHtmlAttr(quote.type);
+            const escapedAnalysis = escapeHtmlAttr(quote.analysis);
             
             document.getElementById('surpriseContent').innerHTML = `
                 <div class="author-quote">
@@ -1558,7 +1574,7 @@
                 <div class="sentence-highlight">${quote.sentence}</div>
                 
                 <div class="options-grid" style="margin-top: 20px;">
-                    <div class="option-card" onclick="revealAnalysis('${quote.predicate}', '${quote.type}', '${quote.analysis}')">
+                    <div class="option-card" onclick="revealAnalysis('${escapedPredicate}', '${escapedType}', '${escapedAnalysis}')">
                         Ver Análise
                     </div>
                 </div>
@@ -1569,15 +1585,28 @@
         }
 
         function revealAnalysis(predicate, type, analysis) {
-            document.getElementById('surpriseContent').innerHTML += `
-                <div class="card" style="margin-top: 20px;">
-                    <h4>Análise:</h4>
-                    <p><strong>Predicado:</strong> <span class="predicate">${predicate}</span></p>
-                    <p><strong>Tipo:</strong> ${type === 'nominal' ? 'Predicado Nominal' : 'Predicado Verbal'}</p>
-                    <p><strong>Explicação:</strong> ${analysis}</p>
-                </div>
+            const surpriseContentEl = document.getElementById('surpriseContent');
+            if (!surpriseContentEl) {
+                console.error("Elemento #surpriseContent não encontrado!");
+                return;
+            }
+
+            const analysisDiv = document.createElement('div');
+            analysisDiv.className = 'card';
+            analysisDiv.style.marginTop = '20px';
+
+            const displayPredicate = escapeHtmlAttr(predicate);
+            const displayAnalysis = escapeHtmlAttr(analysis);
+
+            analysisDiv.innerHTML = `
+                <h4>Análise:</h4>
+                <p><strong>Predicado:</strong> <span class="predicate">${displayPredicate}</span></p>
+                <p><strong>Tipo:</strong> ${type === 'nominal' ? 'Predicado Nominal' : 'Predicado Verbal'}</p>
+                <p><strong>Explicação:</strong> ${displayAnalysis}</p>
             `;
             
+            surpriseContentEl.appendChild(analysisDiv);
+
             updateScore(15);
             checkAchievements();
         }


### PR DESCRIPTION
The 'View Analysis' button in the 'Surprise Challenge' section wasn't working correctly (it wasn't displaying the analysis) for some or all quotes.

I resolved this issue by making the following changes:
1.  Added the `escapeHtmlAttr` function: I created a new utility function to escape special HTML characters (`, &, <, >, ", '`) from strings.
2.  Modified `loadSurprise`: The quote data (`predicate`, `type`, `analysis`) is now escaped using `escapeHtmlAttr` before being inserted as arguments in the `onclick` attribute of the 'View Analysis' button. This prevents JavaScript errors that could occur if the data contained characters that would break the attribute's syntax.
3.  Refactored `revealAnalysis`: I changed the function to use `document.createElement` and `appendChild` instead of `innerHTML +=` to add the analysis card to the DOM. Additionally, the `predicate` and `analysis` data are escaped with `escapeHtmlAttr` before being inserted into the `innerHTML` of the new card, ensuring they are displayed safely as plain text.

These changes ensure that the 'View Analysis' button works robustly and securely, correctly displaying the analysis of literary quotes.